### PR TITLE
Update fields.py

### DIFF
--- a/stdimage/fields.py
+++ b/stdimage/fields.py
@@ -52,8 +52,7 @@ class StdImageFieldFile(ImageFieldFile):
         """
         Renders the image variations and saves them to the storage
         """
-        if not variation['resample']:
-            resample = Image.ANTIALIAS
+        resample = variation.get('resample', Image.ANTIALIAS)
 
         content.seek(0)
 


### PR DESCRIPTION
Avoid unbound local variable error when specifying a resample option in variations.
