### PR TITLE
Avoid KeyError, fix logic of getting default value

### DIFF
--- a/stdimage/fields.py
+++ b/stdimage/fields.py
@@ -53,7 +53,7 @@ class StdImageFieldFile(ImageFieldFile):
         """
         Renders the image variations and saves them to the storage
         """
-        resample = variation['resample'] or Image.ANTIALIAS
+        resample = variation.get('resample', Image.ANTIALIAS)
 
         content.seek(0)
 


### PR DESCRIPTION
Line triggered KeyError if 'resample' was not defined, the existing way of using Image.ANTIALIAS as default was not working.
