### PR TITLE
Fixed check for existing 'admin' variation

### DIFF
--- a/stdimage/fields.py
+++ b/stdimage/fields.py
@@ -142,7 +142,7 @@ class StdImageField(ImageField):
             else:
                 setattr(self, key, None)
 
-        if 'django.contrib.admin' in settings.INSTALLED_APPS and not hasattr(self.variations, 'admin'):
+        if 'django.contrib.admin' in settings.INSTALLED_APPS and not 'admin' in variations:
             self.variations.append({'name': 'admin',
                                     'width': 100,
                                     'height': 100,


### PR DESCRIPTION
wrong variable was checked for existing 'admin' variation, so it was always added.
