### PR TITLE
Make upload_to util classes Django-migrations compatible

### DIFF
--- a/stdimage/utils.py
+++ b/stdimage/utils.py
@@ -3,11 +3,13 @@ from __future__ import (absolute_import, unicode_literals)
 
 import uuid
 from django.utils.text import slugify
+from django.utils.deconstruct import deconstructible
 
 import os
 from .models import StdImageField
 
 
+@deconstructible
 class UploadTo(object):
     file_pattern = "%(name)s.%(ext)s"
     path_pattern = "%(path)s"
@@ -27,6 +29,7 @@ class UploadTo(object):
         self.kwargs = kwargs
 
 
+@deconstructible
 class UploadToUUID(UploadTo):
 
     def __call__(self, instance, filename):
@@ -36,14 +39,17 @@ class UploadToUUID(UploadTo):
         return super(UploadToUUID, self).__call__(instance, filename)
 
 
+@deconstructible
 class UploadToClassNameDir(UploadTo):
     path_pattern = '%(class_name)s'
 
 
+@deconstructible
 class UploadToClassNameDirUUID(UploadToClassNameDir, UploadToUUID):
     pass
 
 
+@deconstructible
 class UploadToAutoSlug(UploadTo):
 
     def __init__(self, populate_from, **kwargs):
@@ -58,6 +64,7 @@ class UploadToAutoSlug(UploadTo):
         return super(UploadToAutoSlug, self).__call__(instance, filename)
 
 
+@deconstructible
 class UploadToAutoSlugClassNameDir(UploadToClassNameDir, UploadToAutoSlug):
     pass
 


### PR DESCRIPTION
Currently, when I try to define my field like this:

>  from stdimage import StdImageField
>  from stdimage.utils import UploadToClassNameDirUUID
> # ...
> 
>  image = StdImageField( upload_to = UploadToClassNameDirUUID())

When I try to create migration files (so I can then syncdb), with command:

> ./manage.py makemigrations

The migration script generation would halt at the StdImage fields with the following errors:

```
raise ValueError("Cannot serialize: %r\nThere are some values Django cannot serialize into migration files.\nFor more, see https://docs.djangoproject.com/en/dev/topics/migrations/#migration-serializing" % value)
ValueError: Cannot serialize: <stdimage.utils.UploadToClassNameDirUUID object at 0x1c0b6d0>
There are some values Django cannot serialize into migration files.
For more, see https://docs.djangoproject.com/en/dev/topics/migrations/#migration-serializing
```

And indeed, when you check out the documentation at https://docs.djangoproject.com/en/dev/topics/migrations/#migration-serializing, you find that for _upload_to_ arguments that accept callables like in this case, there's need to do something more... A little down on that documentation page, they recommend that for some arbitrary classes to be serializable, one can either implement the decostruct() method or use the in-built decorator @deconstructible to make the class serializable by Django migrations.

So, I added the decorator @deconstructible to the classes in utils above, and when I now run 

> ./manage.py makemigrations

It runs without error.

I suggest you integrate this, in order to support Django migrations for fields using StdImageField.
