### PR TITLE
Fix the path splitting when generating variation names

### DIFF
--- a/stdimage/models.py
+++ b/stdimage/models.py
@@ -115,20 +115,14 @@ class StdImageFieldFile(ImageFieldFile):
     @classmethod
     def get_variation_name(cls, file_name, variation_name):
         """Return the variation file name based on the variation."""
-        ext = cls.get_file_extension(file_name)
-        path = file_name.rsplit('/', 1)[0]
-        file_name = file_name.rsplit('/', 1)[-1].rsplit('.', 1)[0]
+        path, ext = os.path.splitext(file_name)
+        path, file_name = os.path.split(path)
         file_name = '{file_name}.{variation_name}{extension}'.format(**{
             'file_name': file_name,
             'variation_name': variation_name,
             'extension': ext,
         })
         return os.path.join(path, file_name)
-
-    @staticmethod
-    def get_file_extension(filename):
-        """Return the file extension."""
-        return os.path.splitext(filename)[1].lower()
 
     def delete(self, save=True):
         self.delete_variations()

--- a/tests/models.py
+++ b/tests/models.py
@@ -118,5 +118,12 @@ class UtilVariationsModel(models.Model):
     )
 
 
+class ThumbnailWithoutDirectoryModel(models.Model):
+    """Save into a generated filename that does not contain any '/' char"""
+    image = StdImageField(
+        upload_to=lambda instance, filename: 'custom.gif',
+        variations={'thumbnail': {'width': 150, 'height': 150}},
+    )
+
 post_delete.connect(pre_delete_delete_callback, sender=SimpleModel)
 pre_save.connect(pre_save_delete_callback, sender=AdminDeleteModel)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -22,7 +22,8 @@ from .models import (
     SimpleModel, ResizeModel, AdminDeleteModel,
     ThumbnailModel, ResizeCropModel, AutoSlugClassNameDirModel,
     UUIDModel,
-    UtilVariationsModel)
+    UtilVariationsModel,
+    ThumbnailWithoutDirectoryModel)
 
 IMG_DIR = os.path.join(settings.MEDIA_ROOT, 'img')
 
@@ -143,6 +144,18 @@ class TestModel(TestStdImage):
         })
         path = os.path.join(IMG_DIR, 'image.gif')
         assert not os.path.exists(path)
+
+    def test_thumbnail_save_without_directory(self):
+        obj = ThumbnailWithoutDirectoryModel.objects.create(
+            image=self.fixtures['100.gif']
+        )
+        obj.save()
+        # Our model saves the images directly into the MEDIA_ROOT directory
+        # not IMG_DIR, under a custom name
+        original = os.path.join(settings.MEDIA_ROOT, 'custom.gif')
+        thumbnail = os.path.join(settings.MEDIA_ROOT, 'custom.thumbnail.gif')
+        assert os.path.exists(original)
+        assert os.path.exists(thumbnail)
 
 
 class TestUtils(TestStdImage):


### PR DESCRIPTION
Using the standard os.path.split function, easier and safer.

The previous code relied on the presence of a '/' char in the filename.
This would failed when using upload_to=callable that returns a simple
filename without any directory.