### PR TITLE
Management Command "rendervariations" Does Not Support Custom Storage Classes

### DIFF
--- a/stdimage/management/commands/rendervariations.py
+++ b/stdimage/management/commands/rendervariations.py
@@ -63,6 +63,7 @@ class Command(BaseCommand):
                 file_name=file_name,
                 variations=field.variations,
                 replace=replace,
+                storage=field.storage
             )
             for file_name in images
         ]
@@ -79,6 +80,7 @@ class Command(BaseCommand):
                 file_name=file_name,
                 variations=field.variations,
                 replace=replace,
+                storage=field.storage
             )
             for file_name in images
         ]


### PR DESCRIPTION
As it stands, the `rendervariations` management command does not respect custom storage classes set on  `StdImageField`. This patch adds an extra arg (`storage=field.storage`) to the dictionaries generated for `args` and `args_list` in the render methods of the command class, so that the storage class is passed to `utils.render_variations`. Otherwise, the `storage` argument defaults to `django.core.files.storage.DefaultStorage`.