### PR TITLE
Raise CommandError on invalid field_path

### DIFF
--- a/stdimage/management/commands/rendervariations.py
+++ b/stdimage/management/commands/rendervariations.py
@@ -6,11 +6,11 @@ import sys
 import traceback
 from multiprocessing import Pool, cpu_count
 
-import progressbar
 from django.apps import apps
 from django.core.files.storage import get_storage_class
-from django.core.management import BaseCommand
+from django.core.management import BaseCommand, CommandError
 
+import progressbar
 from stdimage.utils import render_variations
 
 BAR = None
@@ -45,7 +45,12 @@ class Command(BaseCommand):
         else:
             routes = [options['field_path']]
         for route in routes:
-            app_label, model_name, field_name = route.rsplit('.')
+            try:
+                app_label, model_name, field_name = route.rsplit('.')
+            except ValueError:
+                raise CommandError("Error parsing field_path '{}'. Use format "
+                                   "<app.model.field app.model.field>."
+                                   .format(route))
             model_class = apps.get_model(app_label, model_name)
             field = model_class._meta.get_field(field_name)
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,9 +1,9 @@
 import os
 import time
 
-import pytest
-from django.core.management import call_command
+from django.core.management import CommandError, call_command
 
+import pytest
 from tests.models import ManualVariationsModel, MyStorageModel, ThumbnailModel
 
 
@@ -73,3 +73,14 @@ class TestRenderVariations(object):
             'tests.MyStorageModel.image'
         )
         assert os.path.exists(file_path)
+
+    def test_invalid_field_path(self):
+        with pytest.raises(CommandError) as exc_info:
+            call_command(
+                'rendervariations',
+                'MyStorageModel.image'
+            )
+
+        error_message = "Error parsing field_path 'MyStorageModel.image'. "\
+                        "Use format <app.model.field app.model.field>."
+        assert str(exc_info.value) == error_message


### PR DESCRIPTION
An invalid `field_path` argument for the `rendervariations` command
gave an undescriptive `ValueError`. This commit changes that to an error
message informing the user about the wrong input.

The rearrangement of the imports are the work of the `python-import-sorter` commit-hook.