### PR TITLE
Fix import error on Windows

### DIFF
--- a/stdimage/management/commands/rendervariations.py
+++ b/stdimage/management/commands/rendervariations.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 
-import resource
 import sys
 import traceback
 from multiprocessing import Pool, cpu_count
@@ -13,11 +12,19 @@ from django.core.management import BaseCommand, CommandError
 
 from stdimage.utils import render_variations
 
+try:
+    import resource
+except ImportError:
+    resource = None
+
+
 BAR = None
 
 
 class MemoryUsageWidget(progressbar.widgets.WidgetBase):
     def __call__(self, progress, data):
+        if not resource:
+            return 'RAM: N/A'
         return 'RAM: {0:10.1f} MB'.format(
             resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
         )

--- a/stdimage/management/commands/rendervariations.py
+++ b/stdimage/management/commands/rendervariations.py
@@ -23,11 +23,11 @@ BAR = None
 
 class MemoryUsageWidget(progressbar.widgets.WidgetBase):
     def __call__(self, progress, data):
-        if not resource:
-            return 'RAM: N/A'
-        return 'RAM: {0:10.1f} MB'.format(
-            resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
-        )
+        if resource is not None:
+            return 'RAM: {0:10.1f} MB'.format(
+                resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+            )
+        return 'RAM: N/A'
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
On Windows, Python does not have a `resource` module, which causes django-stdimage to raise an `ImportError` (`ModuleNotFoundError` in Py3).

This patch is a workaround for the issue as discussed in #127. It wraps the import in `try`-`except` and disables memory usage stats in the progress bar when import fails.