### PR TITLE
Attempt to circumvent "OSError: image file is truncated" issue.

### DIFF
--- a/stdimage/models.py
+++ b/stdimage/models.py
@@ -8,7 +8,7 @@ from django.db.models import signals
 from django.db.models.fields.files import (
     ImageField, ImageFieldFile, ImageFileDescriptor
 )
-from PIL import Image, ImageOps
+from PIL import Image, ImageFile, ImageOps
 
 from .validators import MinSizeValidator
 
@@ -69,6 +69,7 @@ class StdImageFieldFile(ImageFieldFile):
 
         resample = variation['resample']
 
+        ImageFile.LOAD_TRUNCATED_IMAGES = True
         with storage.open(file_name) as f:
             with Image.open(f) as img:
                 save_kargs = {}


### PR DESCRIPTION
as detailed here: https://github.com/python-pillow/Pillow/issues/1510

When running the management command 'rendervariations' on a set of about 100.000 images, I bumped into the error message: `image file is truncated (6 bytes not processed)`, which came form PIL that bumped into a faulty image (See PIL/ImageFile.py, line 232). The complete rendering stopped.

The exception isn't caught anywhere. I think ideally one wants a setting to control what to do on such a failure: skip, continue, halt...

For now I followed the suggestion as outlined in referenced Pillow issue, which solved the problem for me. See the changes in stdimage/models.py.

Btw: I tried following the contribution guide, but when i do a `dcc django-stdimage`, I get this error message:

```
dcc.DjangoCCError: The package "django-stdimage" does not support Django-CC.
```

So I offer this PR as a suggestion to fix the issue, but I suppose there are better ways.