### PR TITLE
Allow management command to ignore missing file

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,12 @@ class AsyncImageModel(models.Model)
 You might want to add new variations to a field. That means you need to render new variations for missing fields.
 This can be accomplished using a management command.
 ```bash
-python manage.py rendervariations 'app_name.model_name.field_name' [--replace]
+python manage.py rendervariations 'app_name.model_name.field_name' [--replace] [-i/--ignore-missing]
 ```
 The `replace` option will replace all existing files.
+The `ignore-missing` option will suspend missing source file errors and keep
+rendering variations for other files. Othervise command will stop on first
+missing file.
 
 ### Multi processing
 Since version 2 stdImage supports multiprocessing.

--- a/stdimage/management/commands/rendervariations.py
+++ b/stdimage/management/commands/rendervariations.py
@@ -59,7 +59,8 @@ class Command(BaseCommand):
             images = queryset.values_list(field_name, flat=True).iterator()
             count = queryset.count()
 
-            self.render(field, images, count, replace, igrnore_missing, do_render)
+            self.render(field, images, count, replace, igrnore_missing,
+                        do_render)
 
     @staticmethod
     def render(field, images, count, replace, igrnore_missing, do_render):

--- a/stdimage/management/commands/rendervariations.py
+++ b/stdimage/management/commands/rendervariations.py
@@ -1,4 +1,3 @@
-import logging
 from concurrent.futures import ProcessPoolExecutor
 from multiprocessing import cpu_count
 
@@ -8,8 +7,6 @@ from django.core.files.storage import get_storage_class
 from django.core.management import BaseCommand, CommandError
 
 from stdimage.utils import render_variations
-
-logger = logging.getLogger()
 
 
 class Command(BaseCommand):
@@ -27,12 +24,12 @@ class Command(BaseCommand):
                             default=False,
                             help='Replace existing files.')
 
-        parser.add_argument('--ignore-missing',
+        parser.add_argument('-i', '--ignore-missing',
                             action='store_true',
                             dest='ignore_missing',
                             default=False,
-                            help='Do not rise exception on missing file '
-                                 'and use log.error instead.')
+                            help='Ignore missing source file error and '
+                                 'skip render for that file')
 
     def handle(self, *args, **options):
         replace = options.get('replace', False)
@@ -100,6 +97,6 @@ def render_field_variations(kwargs):
             render_variations(**kwargs)
     except FileNotFoundError as e:
         if not ignore_missing:
-            raise
-        else:
-            logger.error(str(e))
+            raise CommandError(
+                 'Source file was not found, terminating. '
+                 'Use -i/--ignore-missing to skip this error.') from e

--- a/stdimage/management/commands/rendervariations.py
+++ b/stdimage/management/commands/rendervariations.py
@@ -27,16 +27,16 @@ class Command(BaseCommand):
                             default=False,
                             help='Replace existing files.')
 
-        parser.add_argument('--igrnore-missing',
+        parser.add_argument('--ignore-missing',
                             action='store_true',
-                            dest='igrnore_missing',
+                            dest='ignore_missing',
                             default=False,
                             help='Do not rise exception on missing file '
                                  'and use log.error instead.')
 
     def handle(self, *args, **options):
         replace = options.get('replace', False)
-        igrnore_missing = options.get('igrnore_missing', False)
+        ignore_missing = options.get('ignore_missing', False)
         routes = options.get('field_path', [])
         for route in routes:
             try:
@@ -59,11 +59,11 @@ class Command(BaseCommand):
             images = queryset.values_list(field_name, flat=True).iterator()
             count = queryset.count()
 
-            self.render(field, images, count, replace, igrnore_missing,
+            self.render(field, images, count, replace, ignore_missing,
                         do_render)
 
     @staticmethod
-    def render(field, images, count, replace, igrnore_missing, do_render):
+    def render(field, images, count, replace, ignore_missing, do_render):
         kwargs_list = (
             dict(
                 file_name=file_name,
@@ -72,7 +72,7 @@ class Command(BaseCommand):
                 replace=replace,
                 storage=field.storage.deconstruct()[0],
                 field_class=field.attr_class,
-                igrnore_missing=igrnore_missing,
+                ignore_missing=ignore_missing,
             )
             for file_name in images
         )
@@ -90,7 +90,7 @@ class Command(BaseCommand):
 
 def render_field_variations(kwargs):
     kwargs['storage'] = get_storage_class(kwargs['storage'])()
-    igrnore_missing = kwargs.pop('igrnore_missing')
+    ignore_missing = kwargs.pop('ignore_missing')
     do_render = kwargs.pop('do_render')
     try:
         if callable(do_render):
@@ -99,7 +99,7 @@ def render_field_variations(kwargs):
         if do_render:
             render_variations(**kwargs)
     except FileNotFoundError as e:
-        if not igrnore_missing:
+        if not ignore_missing:
             raise
         else:
             logger.error(str(e))

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -83,6 +83,26 @@ class TestRenderVariations:
         after = os.path.getmtime(file_path)
         assert before != after
 
+    def test_ignore_missing(self, image_upload_file):
+        obj = ThumbnailModel.objects.create(image=image_upload_file)
+        file_path = obj.image.path
+        assert os.path.exists(file_path)
+        os.remove(file_path)
+        assert not os.path.exists(file_path)
+        time.sleep(1)
+        with pytest.raises(FileNotFoundError):
+            call_command(
+                'rendervariations',
+                'tests.ThumbnailModel.image',
+                replace=True,
+            )
+        call_command(
+            'rendervariations',
+            'tests.ThumbnailModel.image',
+            '--ignore-missing',
+            replace=True,
+        )
+
     def test_none_default_storage(self, image_upload_file):
         obj = MyStorageModel.customer_manager.create(
             image=image_upload_file

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -90,18 +90,40 @@ class TestRenderVariations:
         os.remove(file_path)
         assert not os.path.exists(file_path)
         time.sleep(1)
-        with pytest.raises(FileNotFoundError):
-            call_command(
-                'rendervariations',
-                'tests.ThumbnailModel.image',
-                replace=True,
-            )
         call_command(
             'rendervariations',
             'tests.ThumbnailModel.image',
             '--ignore-missing',
             replace=True,
         )
+
+    def test_short_ignore_missing(self, image_upload_file):
+        obj = ThumbnailModel.objects.create(image=image_upload_file)
+        file_path = obj.image.path
+        assert os.path.exists(file_path)
+        os.remove(file_path)
+        assert not os.path.exists(file_path)
+        time.sleep(1)
+        call_command(
+            'rendervariations',
+            'tests.ThumbnailModel.image',
+            '-i',
+            replace=True,
+        )
+
+    def test_no_ignore_missing(self, image_upload_file):
+        obj = ThumbnailModel.objects.create(image=image_upload_file)
+        file_path = obj.image.path
+        assert os.path.exists(file_path)
+        os.remove(file_path)
+        assert not os.path.exists(file_path)
+        time.sleep(1)
+        with pytest.raises(CommandError):
+            call_command(
+                'rendervariations',
+                'tests.ThumbnailModel.image',
+                replace=True,
+            )
 
     def test_none_default_storage(self, image_upload_file):
         obj = MyStorageModel.customer_manager.create(


### PR DESCRIPTION
QOL fix allowing rendervariations command to process missing files by logging error instead of complete break.