### PR TITLE
Fix attempting to access deferred fields in stdimage file descriptor

### DIFF
--- a/stdimage/models.py
+++ b/stdimage/models.py
@@ -240,7 +240,8 @@ class StdImageField(ImageField):
 
         :param instance: FileField
         """
-        if getattr(instance, self.name):
+        deferred_field = self.name in instance.get_deferred_fields()
+        if not deferred_field and getattr(instance, self.name):
             field = getattr(instance, self.name)
             if field._committed:
                 for name, variation in list(self.variations.items()):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -168,13 +168,18 @@ class TestModel(TestStdImage):
         assert instance.image.thumbnail.height == 100
 
     def test_defer(self, db, django_assert_num_queries):
-        """Test that set_variations doesn't attempt to use field data
-        when the field is deferred, which would result
-        in another query being executed implicitly.
         """
-        instance = SimpleModel.objects.create(image=self.fixtures['100.gif'])
+        `set_variations` does not access a deferred field.
+
+        Accessing a deferred field would cause Django to do
+        a second implicit database query.
+        """
+        instance = ResizeModel.objects.create(image=self.fixtures['100.gif'])
         with django_assert_num_queries(1):
-            SimpleModel.objects.only('pk').get(pk=instance.pk)
+            deferred = ResizeModel.objects.only('pk').get(pk=instance.pk)
+        with django_assert_num_queries(1):
+            deferred.image
+        assert instance.image.thumbnail == deferred.image.thumbnail
 
 
 class TestUtils(TestStdImage):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -167,6 +167,15 @@ class TestModel(TestStdImage):
         assert instance.image.thumbnail.width == 100
         assert instance.image.thumbnail.height == 100
 
+    def test_defer(self, db, django_assert_num_queries):
+        """Test that set_variations doesn't attempt to use field data
+        when the field is deferred, which would result
+        in another query being executed implicitly.
+        """
+        instance = SimpleModel.objects.create(image=self.fixtures['100.gif'])
+        with django_assert_num_queries(1):
+            SimpleModel.objects.only('pk').get(pk=instance.pk)
+
 
 class TestUtils(TestStdImage):
     """Tests Utils"""


### PR DESCRIPTION
StdImageField.set_variations will no longer attempt to access file field when the file field is deferred.

Before this change, any instance with deferred image field would result in an additional query to retrieve the image field value, as set_variations attempts to overwrite image field value.

Fixes #203 