### PR TITLE
Fix #206 -- Overwrite variations by defaults

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -57,7 +57,7 @@ class TestRenderVariations:
         file_path = obj.image.thumbnail.path
         assert os.path.exists(file_path)
         before = os.path.getmtime(file_path)
-        time.sleep(1)
+        time.sleep(0.1)
         call_command(
             'rendervariations',
             'tests.ThumbnailModel.image',
@@ -71,7 +71,7 @@ class TestRenderVariations:
         file_path = obj.image.thumbnail.path
         assert os.path.exists(file_path)
         before = os.path.getmtime(file_path)
-        time.sleep(1)
+        time.sleep(0.1)
         call_command(
             'rendervariations',
             'tests.ThumbnailModel.image',
@@ -87,7 +87,7 @@ class TestRenderVariations:
         assert os.path.exists(file_path)
         os.remove(file_path)
         assert not os.path.exists(file_path)
-        time.sleep(1)
+        time.sleep(0.1)
         call_command(
             'rendervariations',
             'tests.ThumbnailModel.image',
@@ -101,7 +101,7 @@ class TestRenderVariations:
         assert os.path.exists(file_path)
         os.remove(file_path)
         assert not os.path.exists(file_path)
-        time.sleep(1)
+        time.sleep(0.1)
         call_command(
             'rendervariations',
             'tests.ThumbnailModel.image',
@@ -115,7 +115,7 @@ class TestRenderVariations:
         assert os.path.exists(file_path)
         os.remove(file_path)
         assert not os.path.exists(file_path)
-        time.sleep(1)
+        time.sleep(0.1)
         with pytest.raises(CommandError):
             call_command(
                 'rendervariations',

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,6 @@
 import io
 import os
+import time
 
 import pytest
 from django.conf import settings
@@ -209,6 +210,19 @@ class TestUtils(TestStdImage):
         obj = UtilVariationsModel.objects.create(image=self.fixtures['100.gif'])
         file_path = obj.image.thumbnail.path
         assert os.path.exists(file_path)
+
+    def test_render_variations_overwrite(self, db, image_upload_file):
+        obj = ThumbnailModel.objects.create(image=image_upload_file)
+        file_path = obj.image.thumbnail.path
+        before = os.path.getmtime(file_path)
+        time.sleep(0.1)
+        os.remove(obj.image.path)
+        assert os.path.exists(file_path)
+        obj.image = image_upload_file
+        obj.save()
+        assert file_path == obj.image.thumbnail.path
+        after = os.path.getmtime(file_path)
+        assert before != after, obj.image.path
 
 
 class TestValidators(TestStdImage):


### PR DESCRIPTION
We now overwrite files by default when a new files gets uploaded.
This fixes an issue, where someone might upload a file with the
same name twice the first initial variations get not replaced
with a version of the newer file.
It happens in the least IO consuming way. The rendervariations
management command still behaves as before where variations are
not replaced by default.