### PR TITLE
Remove Django 3.0 DeprecationWarning

### DIFF
--- a/stdimage/validators.py
+++ b/stdimage/validators.py
@@ -2,7 +2,7 @@ from io import BytesIO
 
 from django.core.exceptions import ValidationError
 from django.core.validators import BaseValidator
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from PIL import Image
 
 


### PR DESCRIPTION
Change ugettext_lazy to gettext_lazy to remove Django 3.0 DeprecationWarning

```shell
  from collections import Mapping, Sequence
.../site-packages/stdimage/validators.py:44: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
  message = _('The image you uploaded is too large.'
.../site-packages/stdimage/validators.py:59: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
  message = _('The image you uploaded is too small.'
```