### PR TITLE
Change the stream position after reading in validators

### DIFF
--- a/stdimage/validators.py
+++ b/stdimage/validators.py
@@ -28,8 +28,9 @@ class BaseSizeValidator(BaseValidator):
     def clean(value):
         value.seek(0)
         stream = BytesIO(value.read())
-        img = Image.open(stream)
-        return img.size
+        size = Image.open(stream).size
+        value.seek(0)
+        return size
 
 
 class MaxSizeValidator(BaseSizeValidator):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -227,15 +227,17 @@ class TestUtils(TestStdImage):
 
 class TestValidators(TestStdImage):
     def test_max_size_validator(self, admin_client):
-        admin_client.post('/admin/tests/maxsizemodel/add/', {
+        response = admin_client.post('/admin/tests/maxsizemodel/add/', {
             'image': self.fixtures['600x400.jpg'],
         })
+        assert 'too large' in response.context['adminform'].form.errors['image'][0]
         assert not os.path.exists(os.path.join(IMG_DIR, '800x600.jpg'))
 
     def test_min_size_validator(self, admin_client):
-        admin_client.post('/admin/tests/minsizemodel/add/', {
+        response = admin_client.post('/admin/tests/minsizemodel/add/', {
             'image': self.fixtures['100.gif'],
         })
+        assert 'too small' in response.context['adminform'].form.errors['image'][0]
         assert not os.path.exists(os.path.join(IMG_DIR, '100.gif'))
 
 


### PR DESCRIPTION
It ensures that the image's stream position is always at the start after running validators to prevent issues with further file reading - e.g. another validator which doesn't seek, or another form validation since `seek(0)` is [called at the end](https://github.com/django/django/blob/3.0.5/django/forms/fields.py#L646).

This fixes an issue that I encounter using Wagtail and StdImageField with size validators. I always have the error *Upload a valid image. The file you uploaded was either not an image or a corrupted image.* for the image field. I presume `to_python()` is called on the field after the form validation. I didn't add a relevant test since it could require too much steps to encounter this issue.