### PR TITLE
Fix rendervariations for JPEGField when variation size is None

### DIFF
--- a/stdimage/models.py
+++ b/stdimage/models.py
@@ -304,16 +304,13 @@ class JPEGFieldFile(StdImageFieldFile):
 
         resample = variation["resample"]
 
-        if variation["width"] is None:
-            variation["width"] = image.size[0]
-
-        if variation["height"] is None:
-            variation["height"] = image.size[1]
+        width = image.size[0] if variation["width"] is None else variation["width"]
+        height = image.size[1] if variation["height"] is None else variation["height"]
 
         factor = 1
         while (
-            image.size[0] / factor > 2 * variation["width"]
-            and image.size[1] * 2 / factor > 2 * variation["height"]
+            image.size[0] / factor > 2 * width
+            and image.size[1] * 2 / factor > 2 * height
         ):
             factor *= 2
         if factor > 1:
@@ -322,7 +319,7 @@ class JPEGFieldFile(StdImageFieldFile):
                 resample=resample,
             )
 
-        size = variation["width"], variation["height"]
+        size = width, height
         size = tuple(int(i) if i is not None else i for i in size)
 
         # http://stackoverflow.com/a/21669827

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -270,3 +270,13 @@ class TestJPEGField(TestStdImage):
         assert obj.image.thumbnail.path.endswith("img/100.thumbnail.jpeg")
         assert obj.image.full.width == 100
         assert obj.image.full.height == 100
+
+    def test_convert_multiple(self, db):
+        large = models.JPEGModel.objects.create(image=self.fixtures["600x400.gif"])
+        small = models.JPEGModel.objects.create(image=self.fixtures["100.gif"])
+
+        assert large.image.field._variations["full"] == (None, None)
+        assert small.image.field._variations["full"] == (None, None)
+
+        assert large.image.full.width == 600
+        assert small.image.full.width == 100


### PR DESCRIPTION
This PR fixes a bug when running `python manage.py rendervariations` on a JPEGField when any of the variation sizes are set to `None`. Previously, the `process_variation` method would update the width or height of the variation based on the first image that it encounters, then all subsequent images would be rendered at that size, rather than the full size requested by the variation.