### PR TITLE
test: Adding official django3.2 in testing workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         django-version:
           - "2.2"
           - "3.1"
-          - "3.2rc1"
+          - "3.2"
         extra:
           - ""
           - "progressbar"


### PR DESCRIPTION
https://www.djangoproject.com/weblog/2021/apr/06/django-32-released/