### PR TITLE
Fix #229 -- Delete old file after validation has passed

### DIFF
--- a/stdimage/models.py
+++ b/stdimage/models.py
@@ -264,6 +264,9 @@ class StdImageField(ImageField):
 
         super().__init__(verbose_name=verbose_name, name=name, **kwargs)
 
+        # The attribute name of the old file to use on the model object
+        self._old_attname = "_old_%s" % name
+
     def add_variation(self, name, params):
         variation = self.def_variation.copy()
         variation["kwargs"] = {}
@@ -313,8 +316,18 @@ class StdImageField(ImageField):
         if self.delete_orphans and (data is False or data is not None):
             file = getattr(instance, self.name)
             if file and file._committed and file != data:
-                file.delete(save=False)
+                # Store the old file which should be deleted if the new one is valid
+                setattr(instance, self._old_attname, file)
         super().save_form_data(instance, data)
+
+    def pre_save(self, model_instance, add):
+        if hasattr(model_instance, self._old_attname):
+            # Delete the old file and its variations from the storage
+            old_file = getattr(model_instance, self._old_attname)
+            old_file.delete_variations()
+            old_file.storage.delete(old_file.name)
+            delattr(model_instance, self._old_attname)
+        return super().pre_save(model_instance, add)
 
     def deconstruct(self):
         name, path, args, kwargs = super().deconstruct()

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -7,3 +7,9 @@ class ThumbnailModelForm(forms.ModelForm):
     class Meta:
         model = models.ThumbnailModel
         fields = "__all__"
+
+
+class MinSizeModelForm(forms.ModelForm):
+    class Meta:
+        model = models.MinSizeModel
+        fields = "__all__"

--- a/tests/models.py
+++ b/tests/models.py
@@ -95,7 +95,11 @@ class MaxSizeModel(models.Model):
 
 
 class MinSizeModel(models.Model):
-    image = StdImageField(upload_to=upload_to, validators=[MinSizeValidator(200, 200)])
+    image = StdImageField(
+        upload_to=upload_to,
+        delete_orphans=True,
+        validators=[MinSizeValidator(200, 200)],
+    )
 
 
 class ForceMinSizeModel(models.Model):

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -45,3 +45,16 @@ class TestStdImageField(TestStdImage):
         obj = form.save()
         assert obj.image
         assert os.path.exists(org_path)
+
+    def test_save_form_data__invalid(self, db):
+        instance = models.MinSizeModel.objects.create(
+            image=self.fixtures["600x400.jpg"]
+        )
+        org_path = instance.image.path
+        assert os.path.exists(org_path)
+        form = forms.MinSizeModelForm(
+            files={"image": self.fixtures["100.gif"]},
+            instance=instance,
+        )
+        assert not form.is_valid()
+        assert os.path.exists(org_path)


### PR DESCRIPTION
Note that calling `file.delete(save=False)` in `pre_save()` is not working since - if I understood correctly - it also resets the field on the model object which prevents the new file to be properly saved. Thus, we just delete the file and its variations from the storage.