### PR TITLE
Add migrations to enable a smooth transition to django-pictures

### DIFF
--- a/stdimage/models.py
+++ b/stdimage/models.py
@@ -307,6 +307,19 @@ class StdImageField(ImageField):
                 file.delete(save=False)
         super().save_form_data(instance, data)
 
+    def deconstruct(self):
+        name, path, args, kwargs = super().deconstruct()
+        return (
+            name,
+            path,
+            args,
+            {
+                **kwargs,
+                "variations": self._variations,
+                "force_min_size": self.force_min_size,
+            },
+        )
+
 
 class JPEGFieldFile(StdImageFieldFile):
     @classmethod


### PR DESCRIPTION
We to migrate from django-stimage to pictures, we need to
include variations into the migration model state. This allows
deleting obsolite files during the migration.
