### PR TITLE
Add support for official django versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           python-version: "3.10"
       - uses: actions/checkout@v3
-      - run: sudo apt install -y gettext aspell libenchant-dev
+      - run: sudo apt install -y gettext aspell libenchant-2-dev
       - uses: actions/cache@v3
         with:
           path: ~/.cache/pip
@@ -78,7 +78,8 @@ jobs:
           - "3.10"
         django-version:
           - "3.2"
-          - "4.0"
+          - "4.1"
+          - "4.2"
         extra:
           - "test"
           - "test,progressbar"

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,8 @@ classifier =
     Programming Language :: Python :: 3.10
     Framework :: Django
     Framework :: Django :: 3.2
-    Framework :: Django :: 4.0
+    Framework :: Django :: 4.1
+    Framework :: Django :: 4.2
 
 python_requires =  >=3.8
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,19 @@ class compile_translations(Command):
         pattern = "stdimage/locale/*/LC_MESSAGES/django.po"
         for file in glob.glob(pattern):
             name, ext = os.path.splitext(file)
+
+            # Create the directory since we need this to create .mo files with msgfmt command
+            subprocess.check_call(
+                ["mkdir", "-p", f"{self.build_lib}/{os.path.dirname(name)}"],
+                cwd=BASE_DIR,
+            )  # nosec
+
+            # Create the file
+            subprocess.check_call(
+                ["touch", f"{self.build_lib}/{name}.mo"],
+                cwd=BASE_DIR,
+            )  # nosec
+
             cmd = ["msgfmt", "-c", "-o", f"{self.build_lib}/{name}.mo", file]
             self.announce(
                 "running command: %s" % " ".join(cmd), level=distutils.log.INFO

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -23,7 +23,11 @@ INSTALLED_APPS = (
     "tests",
 )
 
-DEFAULT_FILE_STORAGE = "tests.storage.MyFileSystemStorage"
+STORAGES = {
+    "default": {
+        "BACKEND": "tests.storage.MyFileSystemStorage",
+    },
+}
 
 TEMPLATES = [
     {


### PR DESCRIPTION
Hi

I've made this PR that

- fixes ci & build issues
- add support for Django 4.1 & 4.2
- drop support for Django 4.0 (EOL https://www.djangoproject.com/download/#unsupported-versions)

can we also have a new release after this PR is merged?

Thanks