### PR TITLE
fix deepcopy & pickle for unsaved model instances & empty image fields

### DIFF
--- a/stdimage/models.py
+++ b/stdimage/models.py
@@ -158,9 +158,9 @@ class StdImageFieldFile(ImageFieldFile):
         state = super().__getstate__()
         state["variations"] = {}
         for variation_name in self.field.variations:
-            variation = getattr(self, variation_name)
-            variation_state = variation.__getstate__()
-            state["variations"][variation_name] = variation_state
+            if variation := getattr(self, variation_name, None):
+                variation_state = variation.__getstate__()
+                state["variations"][variation_name] = variation_state
         return state
 
     def __setstate__(self, state):
@@ -207,7 +207,7 @@ class StdImageField(ImageField):
         render_variations=True,
         force_min_size=False,
         delete_orphans=False,
-        **kwargs
+        **kwargs,
     ):
         """
         Standardized ImageField for Django.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,6 @@
 import io
 import os
+import pickle
 import time
 from copy import deepcopy
 
@@ -173,6 +174,20 @@ class TestModel(TestStdImage):
         with django_assert_num_queries(1):
             deferred.image
         assert instance.image.thumbnail == deferred.image.thumbnail
+
+    @pytest.mark.django_db
+    def test_variations_deepcopy_unsaved(self):
+        instance_original = ResizeModel(image=self.fixtures["600x400.jpg"])
+        instance = deepcopy(instance_original)
+        assert isinstance(instance.image, StdImageFieldFile)
+        assert instance.image == instance_original.image
+
+    @pytest.mark.django_db
+    def test_variations_deepcopy_without_image(self):
+        instance_original = ThumbnailModel.objects.create(image=None)
+        instance = deepcopy(instance_original)
+        assert isinstance(instance.image, StdImageFieldFile)
+        assert instance.image == instance_original.image
 
     @pytest.mark.django_db
     def test_variations_deepcopy(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,5 @@
 import io
 import os
-import pickle
 import time
 from copy import deepcopy
 


### PR DESCRIPTION
While trying to upgrade to v6 of this library we stumbled onto what we think is a bug. 

When trying to `deepcopy`, or `pickle` an model instance that: 
- either is unsaved 
- or the imagefield is optional and `None`

Then the `__getstate__` implementation will break since the descriptor doesn't include the variations. 

This was broken since https://github.com/codingjoe/django-stdimage/pull/265, and released in 5.3.3 (I think). 

I understand if this would be not seen as a bug, or not being merged because this library is unmaintained, then we would probably fork it and use the fork until we fully migrated. 